### PR TITLE
Fix DataManager relative path bug and add regression test

### DIFF
--- a/opendeep-researcher/src/utils/data_manager.py
+++ b/opendeep-researcher/src/utils/data_manager.py
@@ -4,7 +4,21 @@ from pathlib import Path
 import uuid
 from typing import Dict, List, Optional
 
-DATA_DIR = Path("../data")
+# NOTE:
+#   DATA_DIR was originally defined using ``Path("../data")``.  This made the
+#   location of the data directory depend on the *current working directory*
+#   at import time.  When the application or tests were run from a different
+#   location, data files would be created outside of the project tree (e.g. in
+#   ``/workspace/data``) rather than inside the repository's ``data`` folder.
+#   Such behaviour made the data manager unreliable and caused tests that rely
+#   on the expected directory structure to fail.
+#
+#   To make the path deterministic we derive it from this module's file
+#   location instead of the process's working directory.  ``__file__`` always
+#   points to ``.../src/utils/data_manager.py`` so taking ``parents[2]`` gives us
+#   the repository root directory (``opendeep-researcher``).  From there we join
+#   the ``data`` directory.
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 
 def ensure_data_structure():
     """Ensure the data directory structure exists."""

--- a/opendeep-researcher/tests/test_data_manager_path.py
+++ b/opendeep-researcher/tests/test_data_manager_path.py
@@ -1,0 +1,21 @@
+import sys
+import os
+import importlib
+from pathlib import Path
+
+def test_data_directory_is_repo_local(monkeypatch, tmp_path):
+    """DataManager should always use repository data directory regardless of CWD."""
+    # Ensure the source path is available on sys.path
+    src_dir = Path(__file__).resolve().parent.parent / "src"
+    sys.path.insert(0, str(src_dir))
+
+    # Change to a temporary directory to simulate running from elsewhere
+    monkeypatch.chdir(tmp_path)
+
+    # Import (or reload) the module after changing CWD so that any relative
+    # paths would resolve incorrectly if based on the working directory.
+    dm = importlib.import_module("utils.data_manager")
+    importlib.reload(dm)
+
+    expected = src_dir.parent / "data"
+    assert dm.DATA_DIR.resolve() == expected.resolve()


### PR DESCRIPTION
## Summary
- Fix `DataManager` to derive the data directory from the module location instead of the process' working directory
- Add regression test confirming data path remains within the repository regardless of current working directory

## Testing
- `pytest opendeep-researcher/tests/test_data_manager_path.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68959d2684a4832284c9617286b33a6f